### PR TITLE
allow `null` to be passed as TTL

### DIFF
--- a/src/Provider/AwsSecretsCachedEnvVarProvider.php
+++ b/src/Provider/AwsSecretsCachedEnvVarProvider.php
@@ -18,7 +18,7 @@ class AwsSecretsCachedEnvVarProvider implements AwsSecretsEnvVarProviderInterfac
     private $decorated;
     private $ttl;
 
-    public function __construct(CacheItemPoolInterface $cacheItemPool, AwsSecretsEnvVarProviderInterface $decorated, int $ttl = 60)
+    public function __construct(CacheItemPoolInterface $cacheItemPool, AwsSecretsEnvVarProviderInterface $decorated, ?int $ttl = 60)
     {
         $this->cacheItemPool = $cacheItemPool;
         $this->decorated = $decorated;


### PR DESCRIPTION
so we can cache them forever (and refresh them async).

passing `0` doesnt work, since the Symfony Cache Adapter treats `0` differently (now+ttl) which would result in "expired immediatly)